### PR TITLE
drag/drop example behavior should match template description

### DIFF
--- a/example/cli/src/app/drag/drag.component.ts
+++ b/example/cli/src/app/drag/drag.component.ts
@@ -21,7 +21,7 @@ export class DragComponent {
   };
 
   options: ITreeOptions = {
-    allowDrag: (node) => true,
+    allowDrag: (node) => node.isLeaf,
     getNodeClone: (node) => ({
       ...node.data,
       id: v4(),


### PR DESCRIPTION
The template for this example describes a tree where only leaf nodes can be dragged. Yet, the tree options are set to unconditionally allow dragging for all nodes. This is contradictory and should be resolved.