### PR TITLE
Use `@Injectable({providedIn: 'root'})` instead of `TreeModule.forRoot()` to provide `TreeDraggedElement`

### DIFF
--- a/projects/angular-tree-component/src/lib/angular-tree-component.module.ts
+++ b/projects/angular-tree-component/src/lib/angular-tree-component.module.ts
@@ -74,12 +74,6 @@ import './polyfills';
   providers: []
 })
 export class TreeModule {
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: TreeModule,
-      providers: [TreeDraggedElement]
-    };
-  }
 }
 
 export {

--- a/projects/angular-tree-component/src/lib/models/tree-dragged-element.model.ts
+++ b/projects/angular-tree-component/src/lib/models/tree-dragged-element.model.ts
@@ -1,6 +1,8 @@
 import { Injectable } from '@angular/core';
 
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class TreeDraggedElement {
   _draggedElement: any = null;
 

--- a/projects/example-app/src/app/app.module.ts
+++ b/projects/example-app/src/app/app.module.ts
@@ -50,7 +50,7 @@ import { DragOverStylingFullTreeComponent } from './dragover-styling/dragover-st
   imports: [
     BrowserModule,
     FormsModule,
-    TreeModule.forRoot(),
+    TreeModule,
     CommonModule,
     AppRoutingModule
   ],


### PR DESCRIPTION
Since Angular 6, the `@Injectable` decorator has allowed for an optional `providedIn` object parameter  to specify the module in which services should be provided as the as [the preferred alternative](https://angular.io/guide/singleton-services#using-providedin) to the `Providers` array in the `@NgModule()` decorator. This PR provides the `TreeDraggedElement` provider using the new `providedIn` syntax to improve bundle sizes by enabling tree-shaking and allowing Angular Tree Component to bundled in lazy-loaded modules without losing the ability to drag & drop across TreeComponents in different modules that running `TreeDraggedElement` as a Service Singleton allows.

The removal of the `TreeModule.forRoot()` method in this PR introduces a breaking change.