### PR TITLE
fix: include mobx as dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "angular-tree-component",
-  "version": "9.0.0",
+  "name": "@circlon/angular-tree-component",
+  "version": "9.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -13337,9 +13337,9 @@
       "dev": true
     },
     "mobx": {
-      "version": "4.15.1",
-      "resolved": "https://registry.npmjs.org/mobx/-/mobx-4.15.1.tgz",
-      "integrity": "sha512-WVRLD/OmEM0fLVPDfdNih4kY+a/ZuP//eK92yqH7uRb2e6H998qf8QqHn90LDc0aXsjcJnqHJ81oVZ+e18jskA=="
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/mobx/-/mobx-4.14.1.tgz",
+      "integrity": "sha512-Oyg7Sr7r78b+QPYLufJyUmxTWcqeQ96S1nmtyur3QL8SeI6e0TqcKKcxbG+sVJLWANhHQkBW/mDmgG5DDC4fdw=="
     },
     "mocha-nightwatch": {
       "version": "2.2.9",
@@ -20065,7 +20065,8 @@
     "tslib": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+      "dev": true
     },
     "tslint": {
       "version": "6.1.2",

--- a/package.json
+++ b/package.json
@@ -5,10 +5,6 @@
   "author": "Circlon Group <os-group@circlon.de>",
   "homepage": "https://github.com/CirclonGroup/angular-tree-component",
   "license": "MIT",
-  "main": "dist/angular-tree-component.umd.js",
-  "js:next": "dist/angular-tree-component.js",
-  "module": "dist/angular-tree-component.js",
-  "types": "dist/angular-tree-component.d.ts",
   "keywords": [
     "ng",
     "angular",
@@ -37,8 +33,8 @@
     "lint:lib": "ng lint angular-tree-component",
     "build:lib": "npm run lint:lib && npm run clean:dist && ng build angular-tree-component",
     "clean:dist": "rimraf dist",
-    "copy:files": "cp ./README.md ./dist/angular-tree-component && cp ./LICENSE ./dist/angular-tree-component",
-    "copy:files:win": "copy README.md .\\dist\\angular-tree-component && copy LICENSE .\\dist\\angular-tree-component",
+    "copy:files": "cp ./README.md ./dist/angular-tree-component && cp ./LICENSE ./dist/angular-tree-component && cp ./projects/angular-tree-component/src/lib/angular-tree-component.css ./dist/angular-tree-component/css/",
+    "copy:files:win": "copy README.md .\\dist\\angular-tree-component && copy LICENSE .\\dist\\angular-tree-component && xcopy .\\projects\\angular-tree-component\\src\\lib\\angular-tree-component.css .\\dist\\angular-tree-component\\css\\",
     "doc": "typedoc --module commonjs --out doc lib/defs/api.ts",
     "clean": "npm run clean:typescript && rimraf node_modules && npm cache clean",
     "clean:typescript": "rimraf dist",
@@ -71,8 +67,7 @@
   "dependencies": {
     "core-js": "^2.5.4",
     "lodash-es": "^4.17.15",
-    "mobx": "^4.15.1",
-    "tslib": "^1.10.0"
+    "mobx": "~4.14.1"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^0.901.10",
@@ -121,6 +116,7 @@
     "testcafe": "^1.0.1",
     "testcafe-browser-provider-saucelabs": "^1.6.1",
     "tsickle": "^0.37.0",
+    "tslib": "^1.10.0",
     "tslint": "^6.1.2",
     "typedoc": "^0.3.12",
     "typescript": "~3.7.4",

--- a/projects/angular-tree-component/ng-package.json
+++ b/projects/angular-tree-component/ng-package.json
@@ -8,5 +8,6 @@
       "mobx": "mobx",
       "lodash-es": "lodash-es"
     }
-  }
+  },
+  "whitelistedNonPeerDependencies": ["core-js", "lodash-es", "mobx"]
 }

--- a/projects/angular-tree-component/package.json
+++ b/projects/angular-tree-component/package.json
@@ -2,12 +2,11 @@
   "name": "@circlon/angular-tree-component",
   "version": "9.0.1",
   "peerDependencies": {
-    "core-js": "^2.5.4",
-    "lodash-es": "^4.17.15",
-    "mobx": "^4.15.1"
+    "core-js": "^2.5.4"
   },
   "dependencies": {
-    "tslib": "^1.10.0"
+    "lodash-es": "^4.17.15",
+    "mobx": "~4.14.1"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^0.901.10",
@@ -56,6 +55,7 @@
     "testcafe": "^1.0.1",
     "testcafe-browser-provider-saucelabs": "^1.6.1",
     "tsickle": "^0.37.0",
+    "tslib": "^1.10.0",
     "tslint": "^6.1.2",
     "typedoc": "^0.3.12",
     "typescript": "~3.7.4",


### PR DESCRIPTION
Only a few projects will use mobx, so we will bundle it with the tree component.