### PR TITLE
feat: remove lodash-es

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12059,11 +12059,6 @@
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
     },
-    "lodash-es": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.20.tgz",
-      "integrity": "sha512-JD1COMZsq8maT6mnuz1UMV0jvYD0E0aUsSOdrr1/nAG3dhqQXwRRgeW0cSqH1U43INKcqxaiVIQNOUDld7gRDA=="
-    },
     "lodash._arraycopy": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "@angular/cdk": "^10.1.3",
     "@angular/forms": "^10.0.0 || ^11.0.0-0",
     "@angular/material": "^10.1.3",
-    "lodash-es": "^4.17.20",
     "mobx": "~4.14.1"
   },
   "devDependencies": {

--- a/projects/angular-tree-component/package.json
+++ b/projects/angular-tree-component/package.json
@@ -39,7 +39,6 @@
     "@angular/core": ">=10.0.0 <11.0.0"
   },
   "dependencies": {
-    "lodash-es": "^4.17.20",
     "mobx": "~4.14.1",
     "tslib": "^2.0.0"
   },

--- a/projects/angular-tree-component/src/lib/components/tree-node-wrapper.component.ts
+++ b/projects/angular-tree-component/src/lib/components/tree-node-wrapper.component.ts
@@ -1,4 +1,4 @@
-import { Component , Input , ViewEncapsulation , TemplateRef } from '@angular/core';
+import { Component , Input , ViewEncapsulation } from '@angular/core';
 import { TreeNode } from '../models/tree-node.model';
 
 @Component({
@@ -42,8 +42,5 @@ export class TreeNodeWrapperComponent {
   @Input() node: TreeNode;
   @Input() index: number;
   @Input() templates: any;
-
-  constructor() {
-  }
 
 }

--- a/projects/angular-tree-component/src/lib/components/tree-node.component.ts
+++ b/projects/angular-tree-component/src/lib/components/tree-node.component.ts
@@ -2,7 +2,6 @@ import {
   Component,
   Input,
   ViewEncapsulation,
-  TemplateRef
 } from '@angular/core';
 import { TreeNode } from '../models/tree-node.model';
 

--- a/projects/angular-tree-component/src/lib/components/tree-viewport.component.ts
+++ b/projects/angular-tree-component/src/lib/components/tree-viewport.component.ts
@@ -1,7 +1,6 @@
 import {
   Component,
   ElementRef,
-  ViewEncapsulation,
   AfterViewInit,
   OnInit,
   OnDestroy,
@@ -9,7 +8,6 @@ import {
 } from '@angular/core';
 import { TreeVirtualScroll } from '../models/tree-virtual-scroll.model';
 import { TREE_EVENTS } from '../constants/events';
-import { throttle } from 'lodash-es';
 
 @Component({
   selector: 'tree-viewport',
@@ -24,9 +22,10 @@ import { throttle } from 'lodash-es';
   `
 })
 export class TreeViewportComponent implements AfterViewInit, OnInit, OnDestroy {
-  setViewport = throttle(() => {
+  setViewport = this.throttle(() => {
     this.virtualScroll.setViewport(this.elementRef.nativeElement);
   }, 17);
+
   private readonly scrollEventHandler: ($event: Event) => void;
 
   constructor(
@@ -64,5 +63,16 @@ export class TreeViewportComponent implements AfterViewInit, OnInit, OnDestroy {
         this.virtualScroll.totalHeight + 'px') ||
       'auto'
     );
+  }
+
+  private throttle(func, timeFrame) {
+    let lastTime = 0;
+    return function () {
+      let now = Date.now();
+      if (now - lastTime >= timeFrame) {
+        func();
+        lastTime = now;
+      }
+    };
   }
 }

--- a/projects/angular-tree-component/src/lib/components/tree.component.ts
+++ b/projects/angular-tree-component/src/lib/components/tree.component.ts
@@ -5,8 +5,6 @@ import { TreeOptions } from '../models/tree-options.model';
 import { ITreeOptions } from '../defs/api';
 import { TreeViewportComponent } from './tree-viewport.component';
 
-import { includes, pick } from 'lodash-es';
-
 @Component({
   selector: 'Tree, tree-root',
   providers: [TreeModel],
@@ -92,8 +90,7 @@ export class TreeComponent implements OnChanges {
   @HostListener('body: keydown', ['$event'])
   onKeydown($event) {
     if (!this.treeModel.isFocused) return;
-    if (includes(['input', 'textarea'],
-      document.activeElement.tagName.toLowerCase())) return;
+    if (['input', 'textarea'].includes(document.activeElement.tagName.toLowerCase())) return;
 
     const focusedNode = this.treeModel.getFocusedNode();
 
@@ -116,12 +113,21 @@ export class TreeComponent implements OnChanges {
       this.treeModel.setData({
         options: changes.options && changes.options.currentValue,
         nodes: changes.nodes && changes.nodes.currentValue,
-        events: pick(this, this.treeModel.eventNames)
+        events: this.pick(this, this.treeModel.eventNames)
       });
     }
   }
 
   sizeChanged() {
     this.viewportComponent.setViewport();
+  }
+
+  private pick(object, keys) {
+    return keys.reduce((obj, key) => {
+      if (object && object.hasOwnProperty(key)) {
+        obj[key] = object[key];
+      }
+      return obj;
+    }, {});
   }
 }

--- a/projects/angular-tree-component/src/lib/defs/api.ts
+++ b/projects/angular-tree-component/src/lib/defs/api.ts
@@ -524,7 +524,7 @@ export interface ITreeModel {
   getVisibleRoots(): ITreeNode[];
   /**
    * @param     path  array of node IDs to be traversed respectively
-   * @param     statrNode  optional. Which node to start traversing from
+   * @param     startNode  optional. Which node to start traversing from
    * @returns   The node, if found - null otherwise
    */
   getNodeByPath(path: any[], startNode?: ITreeNode): ITreeNode;
@@ -535,8 +535,8 @@ export interface ITreeModel {
   getNodeById(id: IDType): ITreeNode;
   /**
    * @param     predicate - either an object or a function, used as a test condition on all nodes.
-   *            Could be every predicate that's supported by lodash's `find` method
-   * @param     statrNode  optional. Which node to start traversing from
+   *            Could be every predicate that's supported by javaScripts Array.prototype.find() method
+   * @param     startNode  optional. Which node to start traversing from
    * @returns   First node that matches the predicate, if found - null otherwise
    */
   getNodeBy(predicate: any, startNode?: ITreeNode): ITreeNode;

--- a/projects/angular-tree-component/src/lib/models/tree-node.model.ts
+++ b/projects/angular-tree-component/src/lib/models/tree-node.model.ts
@@ -4,8 +4,6 @@ import { TreeOptions } from './tree-options.model';
 import { ITreeNode } from '../defs/api';
 import { TREE_EVENTS } from '../constants/events';
 
-import { first, last, some, every } from 'lodash-es';
-
 export class TreeNode implements ITreeNode {
   private handler: IReactionDisposer;
   @computed get isHidden() { return this.treeModel.isHidden(this); };
@@ -16,14 +14,14 @@ export class TreeNode implements ITreeNode {
     if (this.isSelectable()) {
         return this.treeModel.isSelected(this);
     } else {
-      return some(this.children, (node: TreeNode) => node.isSelected);
+      return this.children.some((node: TreeNode) => node.isSelected);
     }
   };
   @computed get isAllSelected() {
     if (this.isSelectable()) {
       return this.treeModel.isSelected(this);
     } else {
-      return every(this.children, (node: TreeNode) => node.isAllSelected);
+      return this.children.every((node: TreeNode) => node.isAllSelected);
     }
   };
   @computed get isPartiallySelected() {
@@ -122,13 +120,13 @@ export class TreeNode implements ITreeNode {
   getFirstChild(skipHidden = false) {
     let children = skipHidden ? this.visibleChildren : this.children;
 
-    return first(children || []);
+    return [].concat(children || []).shift();
   }
 
   getLastChild(skipHidden = false) {
     let children = skipHidden ? this.visibleChildren : this.children;
 
-    return last(children || []);
+    return [].concat(children || []).pop();
   }
 
   findNextNode(goInside = true, skipHidden = false) {

--- a/projects/angular-tree-component/src/lib/models/tree-options.model.ts
+++ b/projects/angular-tree-component/src/lib/models/tree-options.model.ts
@@ -3,8 +3,6 @@ import { TreeModel } from './tree.model';
 import { KEYS } from '../constants/keys';
 import { ITreeOptions } from '../defs/api';
 
-import { defaultsDeep, get, omit, isNumber } from 'lodash-es';
-
 export interface IActionHandler {
   (tree: TreeModel, node: TreeNode, $event: any, ...rest);
 }
@@ -98,10 +96,17 @@ export class TreeOptions {
   actionMapping: IActionMapping;
 
   constructor(private options: ITreeOptions = {}) {
-    this.actionMapping = defaultsDeep({}, this.options.actionMapping, defaultActionMapping);
+    console.log('actionMapping', this.options.actionMapping);
+    console.log('defaultActionMapping', defaultActionMapping);
+
+    this.actionMapping = {
+      ...defaultActionMapping,
+      ...this.options.actionMapping,
+    };
+
     if (options.rtl) {
-      this.actionMapping.keys[KEYS.RIGHT] = <IActionHandler>get(options, ['actionMapping', 'keys', KEYS.RIGHT]) || TREE_ACTIONS.DRILL_UP;
-      this.actionMapping.keys[KEYS.LEFT] = <IActionHandler>get(options, ['actionMapping', 'keys', KEYS.LEFT]) || TREE_ACTIONS.DRILL_DOWN;
+      this.actionMapping.keys[KEYS.RIGHT] = <IActionHandler>options.actionMapping?.keys[KEYS.RIGHT] || TREE_ACTIONS.DRILL_UP;
+      this.actionMapping.keys[KEYS.LEFT] = <IActionHandler>options.actionMapping?.keys[KEYS.LEFT] || TREE_ACTIONS.DRILL_DOWN;
     }
   }
 
@@ -110,7 +115,13 @@ export class TreeOptions {
       return this.options.getNodeClone(node);
     }
 
-    return omit(Object.assign({}, node.data), ['id']);
+    // remove id from clone
+    // keeping ie11 compatibility
+    const nodeClone = Object.assign({}, node.data);
+    if (nodeClone.id) {
+      delete nodeClone.id;
+    }
+    return nodeClone;
   }
 
   allowDrop(element, to, $event?): boolean {
@@ -150,6 +161,6 @@ export class TreeOptions {
   }
 
   get dropSlotHeight(): number {
-    return isNumber(this.options.dropSlotHeight) ? this.options.dropSlotHeight : 2;
+    return typeof this.options.dropSlotHeight === 'number' ? this.options.dropSlotHeight : 2;
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/CirclonGroup/angular-tree-component/blob/master/CONTRIBUTING.md#commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`lodash-es` ist dependency. The `getNodeById` method takes a method for filtering nodes that has to fit the lodash version of find.

Closes #

## What is the new behavior?

`lodash-es` is not a dependency anymore. The `getNodeById` method takes a method for filtering nodes that has to fit the javascript version of find.

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Check if your `getNodeById` method is using a method not compatible with the javascript version of find.

## Other information
