### PR TITLE
fix: return TreeNode for first and last child

### DIFF
--- a/projects/angular-tree-component/src/lib/models/tree-node.model.ts
+++ b/projects/angular-tree-component/src/lib/models/tree-node.model.ts
@@ -120,13 +120,13 @@ export class TreeNode implements ITreeNode {
   getFirstChild(skipHidden = false) {
     let children = skipHidden ? this.visibleChildren : this.children;
 
-    return [].concat(children || []).shift();
+    return children != null && children.length ? children[0] : null;
   }
 
   getLastChild(skipHidden = false) {
     let children = skipHidden ? this.visibleChildren : this.children;
 
-    return [].concat(children || []).pop();
+    return children != null && children.length ? children[children.length - 1] : null;
   }
 
   findNextNode(goInside = true, skipHidden = false) {

--- a/projects/angular-tree-component/src/lib/models/tree.model.ts
+++ b/projects/angular-tree-component/src/lib/models/tree.model.ts
@@ -60,11 +60,13 @@ export class TreeModel implements ITreeModel, OnDestroy {
   }
 
   getFirstRoot(skipHidden = false) {
-    return [].concat(skipHidden ? this.getVisibleRoots() : this.roots).shift();
+    const root = skipHidden ? this.getVisibleRoots() : this.roots;
+    return root != null && root.length ? root[0] : null;
   }
 
   getLastRoot(skipHidden = false) {
-    return [].concat(skipHidden ? this.getVisibleRoots() : this.roots).pop();
+    const root = skipHidden ? this.getVisibleRoots() : this.roots;
+    return root != null && root.length ? root[root.length - 1] : null;
   }
 
   get isFocused() {


### PR DESCRIPTION
closes #893

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/CirclonGroup/angular-tree-component/blob/master/CONTRIBUTING.md#commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #893

## What is the new behavior?

`getFirstChild` and `getLastChild` return `TreeNode` or `null` again.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
