### PR TITLE
fix: reverting change to add scroll eventhandler inside ng cd (#852)

### DIFF
--- a/projects/angular-tree-component/src/lib/components/tree-viewport.component.ts
+++ b/projects/angular-tree-component/src/lib/components/tree-viewport.component.ts
@@ -4,7 +4,6 @@ import {
   AfterViewInit,
   OnInit,
   OnDestroy,
-  NgZone
 } from '@angular/core';
 import { TreeVirtualScroll } from '../models/tree-virtual-scroll.model';
 import { TREE_EVENTS } from '../constants/events';
@@ -30,7 +29,6 @@ export class TreeViewportComponent implements AfterViewInit, OnInit, OnDestroy {
 
   constructor(
     private elementRef: ElementRef,
-    private ngZone: NgZone,
     public virtualScroll: TreeVirtualScroll
   ) {
     this.scrollEventHandler = this.setViewport.bind(this);
@@ -46,9 +44,7 @@ export class TreeViewportComponent implements AfterViewInit, OnInit, OnDestroy {
       this.virtualScroll.fireEvent({ eventName: TREE_EVENTS.initialized });
     });
     let el: HTMLElement = this.elementRef.nativeElement;
-    this.ngZone.runOutsideAngular(() => {
-      el.addEventListener('scroll', this.scrollEventHandler);
-    });
+    el.addEventListener('scroll', this.scrollEventHandler);
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [  x ] The commit message follows our guidelines: https://github.com/CirclonGroup/angular-tree-component/blob/master/CONTRIBUTING.md#commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #852 

## What is the new behavior?

Loading is not stuck anymore when using `virtualScroll: true`

## Does this PR introduce a breaking change?

```
[ ] Yes
[ x ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
